### PR TITLE
Fix github repo links

### DIFF
--- a/examples/App.js
+++ b/examples/App.js
@@ -21,8 +21,8 @@ export default class App extends Component {
           <ul className={classes.nav}>
             <li className={classes.current}><a href="#">usage</a></li>
             <li><a href="#examples">examples</a></li>
-            <li><a href="http://github.com/fatiherikli/react-designer">docs</a></li>
-            <li><a href="http://github.com/fatiherikli/react-designer">show on github</a></li>
+            <li><a href="http://github.com/react-designer/react-designer">docs</a></li>
+            <li><a href="http://github.com/react-designer/react-designer">show on github</a></li>
           </ul>
         </div>
         <div className={classes.usage}>


### PR DESCRIPTION
Noticed the github links in the menu on the github pages site now 404, presumably because the repo has moved

I noticed there's a `gh-pages` branch but I'm not sure what your workflow is so I'm raising this PR against master